### PR TITLE
building package failed

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,4 +1,4 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 README.md
-EXTRA
+#EXTRA #matching is case-insensitive: this drops R/extrapolation from the package

--- a/R/extrapolation.R
+++ b/R/extrapolation.R
@@ -4,8 +4,8 @@
 ################################################
 
 #' @export
-extrapolation <- function(x, ...) {
-  UseMethod("extrapolation", x)
+extrapolation <- function(object, ...) {
+  UseMethod("extrapolation")
 }
 
 #' Extrapolation function for a species discovery model.
@@ -30,7 +30,6 @@ extrapolation.sdm <- function(object, m, ...) {
 
 
 #' @export
-#'
 extrapolation.DP <- function(object, m, ...) {
   alpha <- object$param[1]
   freq <- object$frequencies
@@ -40,7 +39,6 @@ extrapolation.DP <- function(object, m, ...) {
 }
 
 #' @export
-#'
 extrapolation.PY <- function(object, m, ...) {
   alpha <- object$param[1]
   sigma <- object$param[2]
@@ -49,5 +47,3 @@ extrapolation.PY <- function(object, m, ...) {
   K <- length(freq)
   extrapolate_cl_py(m = m, n = n, K = K, sigma = sigma, alpha = alpha)
 }
-
-

--- a/R/extrapolation.R
+++ b/R/extrapolation.R
@@ -4,8 +4,8 @@
 ################################################
 
 #' @export
-extrapolation <- function(object, ...) {
-  UseMethod("extrapolation")
+extrapolation <- function(x, ...) {
+  UseMethod("extrapolation", x)
 }
 
 #' Extrapolation function for a species discovery model.


### PR DESCRIPTION
Howdy pardners,

I failed to build and install the package. The main problem was that you had line `EXTRA` in `.Rbuildignore`: according to the R extension writing manual, matching will be case insensitive, and this will drop `R/extrapolation.R` from the package tarball. An alternative to this change is to rename `R/extrapolation.R`. If `EXTRA` is supposed to be the whole word, adding terminator (`EXTRA$`) will also suffice.

The error occurs when trying to use the canonical way of installing the package:
```bash
> R CMD build BNPvegan
# * building ‘BNPvegan_0.1.0.tar.gz’
> R CMD INSTALL BNPvegan_0.1.0.tar.gz
# ** testing if installed package can be loaded from temporary location
#Warning: S3 methods ‘extrapolation.DP’, ‘extrapolation.PY’, ‘extrapolation.sdm’ were declared in NAMESPACE but not found
#Error: package or namespace load failed for ‘BNPvegan’ in namespaceExport(ns, exports):
# undefined exports: extrapolation
#Error: loading failed
#Execution halted
#ERROR: loading failed
```
The same error also appears when using `devtools::install_github("alessandrozito/BNPvegan")` in **R**.

After this there were only 3 WARNINGS and 4 NOTES which are all easy janitor jobs.

BTW, I like your coding style! Really elegant!

- .Rbuildignore is case-insensitive (see
https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Building-package-tarballs)
  and having EXTRA there will drop R/extrapolation.R from the package
